### PR TITLE
Add sphere

### DIFF
--- a/mcShapes/box.go
+++ b/mcShapes/box.go
@@ -48,6 +48,14 @@ func WithCorner2(xyz XYZ) BoxOption {
 	return func(b *Box) { b.corner2 = xyz }
 }
 
+// At sets the location for a single voxel box
+func At(xyz XYZ) BoxOption {
+	return func(b *Box) {
+		b.corner1 = xyz
+		b.corner2 = xyz
+	}
+}
+
 // Orient box to new direction
 // North fall runs west to east
 // East fall runs north to south

--- a/mcShapes/sphere.go
+++ b/mcShapes/sphere.go
@@ -1,0 +1,74 @@
+package mcshapes
+
+import (
+	"io"
+	"math"
+)
+
+// Sphere is a hollow sphere defined by a center
+// point and a radius with a given surface
+type Sphere struct {
+	surface string
+	radius  int
+	center  XYZ
+}
+
+// NewSphere creates a new sphere
+func NewSphere(opts ...SphereOption) *Sphere {
+	s := &Sphere{
+		//default surface is "minecraft:glass"
+		surface: "minecraft:glass",
+		//default radius 30
+		radius: 30,
+		//default center to bring whole sphere on surface
+		center: XYZ{Y: 30},
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+// SphereOption sets various options for NewSphere
+type SphereOption func(*Sphere)
+
+// WithRadius set the radius of the sphere
+func WithRadius(r int) SphereOption {
+	return func(s *Sphere) { s.radius = r }
+}
+
+// WithSphereSurface set the surface of the sphere
+func WithSphereSurface(surface string) SphereOption {
+	return func(s *Sphere) { s.surface = surface }
+}
+
+// WithCenter set the center point of the sphere
+// note that the center should be at least radius
+// for Y, otherwise sphere is below ground level
+func WithCenter(c XYZ) SphereOption {
+	return func(s *Sphere) { s.center = c }
+}
+
+// WriteShape satisfies ObjectWriter interface
+func (s *Sphere) WriteShape(w io.Writer) error {
+	var voxels []ObjectWriter
+	for x := -s.radius; x <= s.radius; x++ {
+		for y := -s.radius; y <= s.radius; y++ {
+			for z := -s.radius; z <= s.radius; z++ {
+				sqs := math.Pow(float64(x), 2) +
+					math.Pow(float64(y), 2) +
+					math.Pow(float64(z), 2)
+				outline := math.Sqrt(sqs)
+				if outline >= float64(s.radius-2) && outline <= float64(s.radius) {
+					b := NewBox(
+						At(XYZ{X: x + s.center.X, Y: y + s.center.Y, Z: z + s.center.Z}),
+						WithSurface(s.surface))
+					voxels = append(voxels, b)
+				}
+			}
+		}
+	}
+	return WriteShapes(w, voxels)
+}

--- a/mcShapes/sphere_test.go
+++ b/mcShapes/sphere_test.go
@@ -1,0 +1,26 @@
+package mcshapes
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/benmcclelland/mcrender"
+)
+
+// Test a sphere
+func TestSphere(t *testing.T) {
+	b := NewSphere(WithSphereSurface("testsurface"),
+		WithRadius(50),
+		//hovering sphere
+		WithCenter(XYZ{Y: 70}))
+
+	var buf bytes.Buffer
+	if err := b.WriteShape(&buf); err != nil {
+		t.Errorf("WriteShape: %v", err)
+	}
+
+	err := mcrender.CreateSTLFromInput(&buf, "spheretest.stl")
+	if err != nil {
+		t.Errorf("create STL: %v", err)
+	}
+}


### PR DESCRIPTION
This is a brute force algorithm, so could be optimized later.

The At() option is added to Box to allow us to specify a single
voxel box at a given location.

Note that the option to set the surface type of sphere is
WithSphereSurface() because WithSurface is already defined
for the BoxOption type.